### PR TITLE
aggregate support.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -63,12 +63,9 @@ exports.promisifyAll = function (mongoose, Promise, suffix) {
 
 	/*
 	 * promisify `mongoose.Model` static methods by appending a suffix, default `Async`
-	 * aggregateAsync does not work
-	 * because Aggregate is not exposed by mongoose
 	 * */
 	var modelStaticsList = [
-		// 'aggregate',
-		'count', 'create', 'distinct', 'ensureIndexes',
+		'aggregate', 'count', 'create', 'distinct', 'ensureIndexes',
 		'find', 'findById', 'findByIdAndRemove', 'findByIdAndUpdate',
 		'findOne', 'findOneAndRemove', 'findOneAndUpdate',
 		'geoNear', 'geoSearch', 'mapReduce', 'populate', 'remove', 'update'
@@ -138,5 +135,4 @@ exports.promisifyAll = function (mongoose, Promise, suffix) {
 	/*
 	 * TODO promisify custom instance methods
 	 * */
-
 }


### PR DESCRIPTION
Mongoose has been add aggregation builder in version 3.8.
ref: https://github.com/LearnBoost/mongoose/wiki/3.8-Release-Notes#aggregation-builder
